### PR TITLE
feat: rewrite add account for stack v3

### DIFF
--- a/app/components/AccountConnection.jsx
+++ b/app/components/AccountConnection.jsx
@@ -24,7 +24,7 @@ const AccountConnection = ({ t, connector, fields, dirty, error, submit, submitt
         </p>
         <h3>{t('dataType title')}</h3>
         <ul class='account-datas'>
-          {connector.dataType.map(data =>
+          {connector.dataType && connector.dataType.map(data =>
             <DataItem
               dataType={data}
               hex={connector.color.hex}

--- a/app/containers/ConnectorManagement.jsx
+++ b/app/containers/ConnectorManagement.jsx
@@ -61,6 +61,7 @@ export default class ConnectorManagement extends Component {
       connector: this.sanitize(connector),
       isConnected: connector.accounts.length !== 0,
       isInstalled: this.isInstalled(connector),
+      isWorking: false,
       selectedAccount: 0,
       fields: this.configureFields(fields, context.t, name),
       submitting: false,
@@ -69,15 +70,14 @@ export default class ConnectorManagement extends Component {
       error: null
     }
 
-    this.store
-      .fetchOrInstallConnector(props.params.account)
+    this.store.fetchKonnectorInfos(props.params.account)
+      .then(konnector => {
+        this.setState({
+          connector: konnector,
+          isWorking: false
+        })
+      })
       .catch(error => {
-        // Errors from stack, should be encapsulated by CozyClient calls in
-        // the near future
-        if (error.errors) {
-          error = error.errors[0].detail
-        }
-
         Notifier.error(t(error.message || error))
         this.gotoParent()
       })
@@ -89,11 +89,11 @@ export default class ConnectorManagement extends Component {
 
   render () {
     const { slug, color, name, customView, accounts, lastImport } = this.state.connector
-    const { isConnected, isInstalled, selectedAccount } = this.state
+    const { isConnected, selectedAccount, isWorking } = this.state
     const { t } = this.context
 
-    if (!isInstalled) {
-      return <ConnectorDialog slug={slug} color={color.css} enableDefaultIcon>
+    if (isWorking) {
+      return <ConnectorDialog slug={slug} color={color ? color.css : ''} enableDefaultIcon>
         {/* @TODO temporary component, prefer the use of a clean spinner comp when UI is updated */}
         <div class='installing'>
           <div class='installing-spinner' />

--- a/app/containers/ConnectorManagement.jsx
+++ b/app/containers/ConnectorManagement.jsx
@@ -102,7 +102,7 @@ export default class ConnectorManagement extends Component {
       </ConnectorDialog>
     } else {
       return (
-        <ConnectorDialog slug={slug} color={color.css} enableDefaultIcon>
+        <ConnectorDialog slug={slug} color={color ? color.css : ''} enableDefaultIcon>
           {isConnected
             ? <AccountManagement
               name={name}

--- a/app/lib/accounts.js
+++ b/app/lib/accounts.js
@@ -1,0 +1,15 @@
+/* accounts lib ready to be added to cozy-client-js */
+
+const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
+
+export function create (cozy, konnector, auth, name = '') {
+  return cozy.data.create(ACCOUNTS_DOCTYPE, {
+    name: name,
+    account_type: konnector.vendorLink,
+    status: 'PENDING',
+    auth: {
+      login: auth.login,
+      password: auth.password
+    }
+  })
+}

--- a/app/lib/konnectors.js
+++ b/app/lib/konnectors.js
@@ -1,0 +1,61 @@
+/* konnector lib ready to be added to cozy-client-js */
+const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
+
+const STATE_READY = 'ready'
+
+export function addAccount (cozy, konnector, account) {
+  return Promise.resolve(konnector)
+}
+
+export function fetchManifest (cozy, source) {
+  return cozy.fetchJSON('GET', `/konnectors/manifests?Source=${encodeURIComponent(source)}`)
+}
+
+let cachedSlugIndex
+function getSlugIndex (cozy) {
+  return cachedSlugIndex
+    ? Promise.resolve(cachedSlugIndex)
+      : cozy.data.defineIndex(KONNECTORS_DOCTYPE, ['slug'])
+          .then(index => {
+            cachedSlugIndex = index
+            return index
+          })
+}
+
+export function findBySlug (cozy, slug) {
+  if (!slug) throw new Error('Missing `slug` paramater')
+
+  return getSlugIndex(cozy)
+    .then(index => cozy.data.query(index, {selector: {slug: slug}}))
+    .then(list => list.length ? list[0] : null)
+}
+
+export function install (cozy, slug, source, timeout = 120000) {
+  if (!slug) throw new Error('Missing `slug` paramater for konnector')
+  if (!source) throw new Error('Missing `source` parameter for konnector')
+
+  return cozy.fetchJSON('POST', `/konnectors/${slug}?Source=${encodeURIComponent(source)}`)
+      .then(konnector => new Promise((resolve, reject) => {
+        const idTimeout = setTimeout(() => {
+          reject(new Error('Konnector installation timed out'))
+        }, timeout)
+
+        // monitor the status of the connector
+        // TODO: replace by a polling abstraction utility.
+        const idInterval = setInterval(() => {
+          cozy.data.find(KONNECTORS_DOCTYPE, konnector._id)
+            .then(konnector => {
+              if (konnector.state === STATE_READY) {
+                clearTimeout(idTimeout)
+                clearInterval(idInterval)
+                resolve(konnector)
+              }
+            })
+            .catch(error => {
+              clearTimeout(idTimeout)
+              clearInterval(idInterval)
+              reject(error)
+            })
+        }, 1000)
+      }))
+}

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -56,6 +56,7 @@
   "error occurred during import:": "An error occurred during the last import:",
   "import server error": "Server error occured while importing.",
   "open selected folder": "Open selected folder",
+  "konnector default base folder": "Administration",
   "konnector description darty": "Import all your Darty bills in your Cozy.",
   "konnector description malakoff_mederic": "Import your Malakoff Mederic reimbursements in your Cozy.",
   "konnector description meetup": "Synchronize your Meetup calendar with your Cozy. This konnector requires the Calendar application.",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "browser-sync-webpack-plugin": "1.1.3",
     "copy-webpack-plugin": "4.0.0",
     "cozy-bar": "^3.0.0-beta19",
-    "cozy-client-js": "^0.2.1",
+    "cozy-client-js": "^0.2.3",
     "cozy-ui": "^3.0.0-beta20",
     "css-loader": "0.25.0",
     "css-mqpacker": "5.0.1",

--- a/vendor/assets/manifest.webapp
+++ b/vendor/assets/manifest.webapp
@@ -24,7 +24,18 @@
     },
     "konnectors": {
       "description": "Required to get the list of konnectors",
-      "type": "io.cozy.konnectors"
+      "type": "io.cozy.konnectors",
+      "verbs": ["GET", "POST", "PUT"]
+    },
+    "accounts": {
+      "description": "Required to manage accounts associated to konnectors",
+      "type": "io.cozy.accounts",
+      "verbs": ["GET", "POST", "PUT"]
+    },
+    "files": {
+      "description": "Required to access folders",
+      "type": "io.cozy.files",
+      "verbs": ["GET", "POST", "PUT"]
     }
   },
   "routes": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,9 +1460,9 @@ cozy-bar@^3.0.0-beta19:
   dependencies:
     node-polyglot "^2.2.2"
 
-cozy-client-js@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.2.1.tgz#1404f4a22be25dd8dfbfd496957bb4c127beca6e"
+cozy-client-js@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.2.3.tgz#ddb7bb7e574b3f42b2a79670c543667835874d42"
 
 cozy-ui@^3.0.0-beta20:
   version "3.0.0-beta20"


### PR DESCRIPTION
This PR follows https://github.com/cozy/cozy-my-accounts/pull/1 and implements [konnector workflow described here](https://github.com/cozy/cozy-stack/blob/master/docs/konnectors_workflow_example.md) until step 6.

So, there is still to do :

- [ ] 7. Install the konnector : the call is made, succeed, but throws an error in UI- - 
- [ ] 8. Update konnector permission for folder
- [ ] 9. Add a reference to the konnector in the folder
- [ ] 10. Create a job to run the konnector for the first time
- [ ] 11. Follow the job execution with --realtime-- polling
- [ ] 12. Add a trigger

I used two new library : `accounts` and `konnectors`. They are built like cozy-client-js ones and I think we should keep this format for all our library accessing our business objects.