### PR TITLE
feat: serve mocked intent for CREATE io.cozy.accounts

### DIFF
--- a/app/components/Loading.jsx
+++ b/app/components/Loading.jsx
@@ -1,0 +1,18 @@
+/** @jsx h */
+import {h} from 'preact'
+import { translate } from '../plugins/preact-polyglot'
+
+export const Loading = ({ t, loadingType, noMargin }) => {
+  return (
+    <div
+      className={noMargin
+        ? 'coz-loading--no-margin'
+        : 'coz-loading'
+      }
+    >
+      {loadingType && <p>{t(`Loading.${loadingType}`)}</p>}
+    </div>
+  )
+}
+
+export default translate()(Loading)

--- a/app/containers/IntentService.jsx
+++ b/app/containers/IntentService.jsx
@@ -1,0 +1,12 @@
+/** @jsx h */
+import { h, Component } from 'preact'
+
+export default class IntentService extends Component {
+  render () {
+    return (
+      <div>
+        <h1>Intent Service</h1>
+      </div>
+    )
+  }
+}

--- a/app/containers/IntentService.jsx
+++ b/app/containers/IntentService.jsx
@@ -1,23 +1,46 @@
-/* global cozy */
 /** @jsx h */
 import { h, Component } from 'preact'
 
 import Loading from '../components/Loading'
 
 export default class IntentService extends Component {
-  constructor (props) {
-    super(props)
+  constructor (props, context) {
+    super(props, context)
+    this.store = context.store
+
+    const {window} = props
 
     this.state = {
       isFetching: true
     }
+
+    // Maybe the logic getting the intent from location.search should be
+    // encapsulated in cozy.client.createService
+    const intent = window.location.search.split('=')[1]
+
+    this.store.createIntentService(intent, window)
+      .then(service => this.setState({
+        isFetching: false,
+        service: service
+      }))
+      .catch(error => {
+        this.setState({
+          isFetching: false,
+          error: error
+        })
+      })
   }
 
   render () {
-    const { isFetching } = this.state
+    const { isFetching, error } = this.state
+    const { t } = this.context
     return (
-      <div>
+      <div class='coz-service'>
         { isFetching && <Loading /> }
+        { error && <div class='coz-error coz-service-error'>
+          <h1>{t('intent.service.error')}</h1>
+          <p>{t('intent.service.error.cause', {error: error})}</p>
+        </div>}
       </div>
     )
   }

--- a/app/containers/IntentService.jsx
+++ b/app/containers/IntentService.jsx
@@ -52,6 +52,24 @@ export default class IntentService extends Component {
       })
   }
 
+  onTerminate () {
+    const { service } = this.state
+
+    const accountMock = {
+      _id: '1111aaaa11111aaaab'
+    }
+
+    service.terminate(accountMock)
+  }
+
+  onCancel () {
+    const { service } = this.state
+
+    service.cancel
+      ? service.cancel()
+        : service.terminate(null)
+  }
+
   render () {
     const { isFetching, error, konnector } = this.state
     const { t } = this.context
@@ -63,7 +81,21 @@ export default class IntentService extends Component {
           <p>{t('intent.service.error.cause', {error: error.message})}</p>
         </div>}
         { !isFetching && !error && konnector &&
-          <h1>{konnector.name}</h1>
+          <div class='coz-create-account'>
+            <h1>{konnector.name}</h1>
+            <div>
+              <button
+                class='coz-btn coz-btn--secondary'
+                onClick={() => this.onCancel()}>
+                {t('intent.service.cancel')}
+              </button>
+              <button
+                class='coz-btn cozy-btn--highlight'
+                onClick={() => this.onTerminate()}>
+                {t('intent.service.terminate')}
+              </button>
+            </div>
+          </div>
         }
       </div>)
   }

--- a/app/containers/IntentService.jsx
+++ b/app/containers/IntentService.jsx
@@ -1,11 +1,23 @@
+/* global cozy */
 /** @jsx h */
 import { h, Component } from 'preact'
 
+import Loading from '../components/Loading'
+
 export default class IntentService extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      isFetching: true
+    }
+  }
+
   render () {
+    const { isFetching } = this.state
     return (
       <div>
-        <h1>Intent Service</h1>
+        { isFetching && <Loading /> }
       </div>
     )
   }

--- a/app/containers/IntentService.jsx
+++ b/app/containers/IntentService.jsx
@@ -14,15 +14,36 @@ export default class IntentService extends Component {
       isFetching: true
     }
 
-    // Maybe the logic getting the intent from location.search should be
+    // Maybe the logic about getting the intent from location.search should be
     // encapsulated in cozy.client.createService
     const intent = window.location.search.split('=')[1]
 
     this.store.createIntentService(intent, window)
-      .then(service => this.setState({
-        isFetching: false,
-        service: service
-      }))
+      .then(service => {
+        this.setState({
+          service: service
+        })
+
+        const data = service.getData()
+
+        if (!data || !data.slug) {
+          throw new Error('Unexpected data from intent')
+        }
+
+        return this.store.fetchKonnectorInfos(data.slug)
+      })
+      .then(konnector => {
+        if (!konnector) {
+          throw new Error(`Unknown konnector`)
+        }
+
+        this.setState({
+          isFetching: false,
+          konnector: konnector
+        })
+
+        return konnector
+      })
       .catch(error => {
         this.setState({
           isFetching: false,
@@ -32,16 +53,18 @@ export default class IntentService extends Component {
   }
 
   render () {
-    const { isFetching, error } = this.state
+    const { isFetching, error, konnector } = this.state
     const { t } = this.context
     return (
       <div class='coz-service'>
         { isFetching && <Loading /> }
         { error && <div class='coz-error coz-service-error'>
           <h1>{t('intent.service.error')}</h1>
-          <p>{t('intent.service.error.cause', {error: error})}</p>
+          <p>{t('intent.service.error.cause', {error: error.message})}</p>
         </div>}
-      </div>
-    )
+        { !isFetching && !error && konnector &&
+          <h1>{konnector.name}</h1>
+        }
+      </div>)
   }
 }

--- a/app/initKonnectors.json
+++ b/app/initKonnectors.json
@@ -25,6 +25,18 @@
   },
   {
     "accounts":[],
+    "slug":"maif",
+    "name":"MAIF",
+    "vendorLink":"maif.fr",
+    "description":"konnector description maif",
+    "category":"health",
+    "color":{"hex":"#007858","css":"#007858"},
+    "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
+    "dataType":["bill"],
+    "repo": "git://github.com/cozy/cozy-konnector-maif.git"
+  },
+  {
+    "accounts":[],
     "slug":"trainline",
     "name":"Trainline",
     "vendorLink":"www.trainline.fr",

--- a/app/lib/MyAccountsStore.js
+++ b/app/lib/MyAccountsStore.js
@@ -230,6 +230,10 @@ export default class MyAccountsStore {
           : data.then(Promise.reject.bind(Promise))
       })
   }
+
+  createIntentService (intent, window) {
+    return cozy.client.intents.createService(intent, window)
+  }
 }
 
 export class Provider extends Component {

--- a/app/lib/MyAccountsStore.js
+++ b/app/lib/MyAccountsStore.js
@@ -132,14 +132,14 @@ export default class MyAccountsStore {
           konnector = this.connectors.find(k => k.slug === slug)
         }
 
-        return konnectors.fetchManifest(cozy.client, konnector.repo)
+        return konnector ? konnectors.fetchManifest(cozy.client, konnector.repo)
           .then(this.manifestToKonnector)
           .catch(error => {
             console.warn && console.warn(`Cannot fetch konnector's manifest (Error ${error.status})`)
             return konnector
-          })
+          }) : null
       })
-      .then(konnector => this.updateConnector(konnector))
+      .then(konnector => konnector ? this.updateConnector(konnector) : null)
   }
 
   getInstalledConnector (slug) {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -114,6 +114,8 @@
   "konnector description podcast": "Download your favourite audio podcasts from a RSS feed. This import can take a while.",
   "konnector description materiel_net": "Import your Materiel.net bills. This konnector requires the Files application to store the bill PDF files.",
   "konnector installation timeout error": "Konnector installation timed out.",
+  "intent.service.error": "Service failed to initialize. Sorry for the inconvenience.",
+  "intent.service.error.cause": "Cause: %{error}",
   "notification import error": "an error occurred during import of data",
   "notification malakoff_mederic": "%{smart_count} new reimbursement imported |||| %{smart_count} new reimbursements imported",
   "notification prefix": "Konnector %{name}:",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -116,6 +116,8 @@
   "konnector installation timeout error": "Konnector installation timed out.",
   "intent.service.error": "Service failed to initialize. Sorry for the inconvenience.",
   "intent.service.error.cause": "Cause: %{error}",
+  "intent.service.cancel": "Cancel",
+  "intent.service.terminate": "Terminate",
   "notification import error": "an error occurred during import of data",
   "notification malakoff_mederic": "%{smart_count} new reimbursement imported |||| %{smart_count} new reimbursements imported",
   "notification prefix": "Konnector %{name}:",

--- a/app/services.ejs
+++ b/app/services.ejs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{.Locale}}">
+<meta charset="utf-8">
+<title><%= htmlWebpackPlugin.options.title %></title>
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#ffffff">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+  <link rel="stylesheet" href="<%- file %>">
+<% }); %>
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+  <script src="<%- file %>" defer></script>
+<% }); %>
+<% if (__STACK_ASSETS__) { %>
+{{.CozyClientJS}}
+<% } %>
+<div
+  role="application"
+  data-cozy-token="{{.Token}}"
+  data-cozy-domain="{{.Domain}}"
+  data-cozy-locale="{{.Locale}}"
+  data-cozy-app-name="{{.AppName}}"
+  data-cozy-icon-path="{{.IconPath}}"
+>

--- a/app/services.jsx
+++ b/app/services.jsx
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
   render((
     <Provider store={store}>
       <I18n context={context} locale={lang}>
-        <IntentService />
+        <IntentService window={window} />
       </I18n>
     </Provider>
   ), document.querySelector('[role=application]'))

--- a/app/services.jsx
+++ b/app/services.jsx
@@ -1,0 +1,37 @@
+import 'babel-polyfill'
+/** @jsx h */
+/* global cozy */
+import { h, render } from 'preact'
+
+import { I18n } from './plugins/preact-polyglot'
+import MyAccountsStore, { Provider } from './lib/MyAccountsStore'
+
+import IntentService from './containers/IntentService'
+
+import './styles/index.styl'
+
+const lang = document.documentElement.getAttribute('lang') || 'en'
+const context = window.context || 'cozy'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('[role=application]')
+  const data = root.dataset
+  cozy.client.init({
+    cozyURL: '//' + data.cozyDomain,
+    token: data.cozyToken
+  })
+
+  // store
+  window.initKonnectors = require('./initKonnectors.json')
+  window.initFolders = require('./initFolders.json')
+
+  const store = new MyAccountsStore(window.initKonnectors, window.initFolders, context)
+
+  render((
+    <Provider store={store}>
+      <I18n context={context} locale={lang}>
+        <IntentService />
+      </I18n>
+    </Provider>
+  ), document.querySelector('[role=application]'))
+})

--- a/app/services.jsx
+++ b/app/services.jsx
@@ -8,7 +8,7 @@ import MyAccountsStore, { Provider } from './lib/MyAccountsStore'
 
 import IntentService from './containers/IntentService'
 
-import './styles/index.styl'
+import './styles/services.styl'
 
 const lang = document.documentElement.getAttribute('lang') || 'en'
 const context = window.context || 'cozy'

--- a/app/styles/index.styl
+++ b/app/styles/index.styl
@@ -13,6 +13,8 @@
 
 @import './dialog.styl'
 
+@import './loading.styl'
+
 @import './notifier.styl'
 
 // inside modal spinner

--- a/app/styles/loading.styl
+++ b/app/styles/loading.styl
@@ -1,0 +1,34 @@
+.coz-loading, .coz-loading--no-margin
+  text-align center
+  &:before
+    content     ''
+    margin      em(80px) auto 0
+    width       em(80px)
+    height      em(80px)
+    @extend $icon-spinner-blue
+
+  h2
+    font-size(24px)
+    margin         em(33px) auto 0
+    line-height    1.3
+    color          grey-08
+    letter-spacing -0.2px
+  p
+    margin-top  em(15px)
+    color       grey-11
+    line-height 1.5
+
+.coz-loading--no-margin
+    &:before
+        margin 0
+
+
+@media (max-width: (1023/basefont)rem)
+  .coz-empty
+    &:before
+      width  em(55px)
+      height em(55px)
+    h2
+      margin em(33px) 1.5em 0
+    p
+      margin em(5px) 1.5em 0

--- a/app/styles/services.styl
+++ b/app/styles/services.styl
@@ -1,0 +1,7 @@
+@import 'cozy-ui/defaults'
+@import 'cozy-ui'
+
+@import './loading.styl'
+
+.coz-service
+    @extend $centerized

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -4,7 +4,7 @@ const webpack = require('webpack')
 
 module.exports = {
   output: {
-    filename: 'app.[hash].min.js'
+    filename: '[name].[hash].min.js'
   },
   devtool: '#cheap-module-source-map',
   plugins: [

--- a/config/webpack.vars.js
+++ b/config/webpack.vars.js
@@ -6,5 +6,5 @@ const production = process.env.NODE_ENV === 'production'
 
 module.exports = {
   production: production,
-  extractor: new ExtractTextPlugin(`app${production ? '.[hash].min' : ''}.css`)
+  extractor: new ExtractTextPlugin(`[name]${production ? '.[hash].min' : ''}.css`)
 }

--- a/vendor/assets/manifest.webapp
+++ b/vendor/assets/manifest.webapp
@@ -43,6 +43,11 @@
       "folder": "/",
       "index": "index.html",
       "public": false
+    },
+    "/services": {
+      "folder": "/services",
+      "index": "index.html",
+      "public": false
     }
   }
 }

--- a/vendor/assets/manifest.webapp
+++ b/vendor/assets/manifest.webapp
@@ -49,5 +49,10 @@
       "index": "index.html",
       "public": false
     }
-  }
+  },
+  "intents": [{
+    "action": "CREATE",
+    "type": ["io.cozy.accounts"],
+    "href": "/services"
+  }]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,17 @@ let plugins = [
     template: 'app/index.ejs',
     title: pkg.name,
     inject: false,
+    excludeChunks: ['services'],
+    minify: {
+      collapseWhitespace: true
+    }
+  }),
+  new HtmlWebpackPlugin({
+    template: 'app/services.ejs',
+    title: `${pkg.name} services`,
+    filename: 'services/index.html',
+    inject: false,
+    chunks: ['services'],
     minify: {
       collapseWhitespace: true
     }
@@ -107,10 +118,13 @@ let plugins = [
  */
 
 module.exports = merge(require('./config/webpack.config.base.js'), {
-  entry: './app',
+  entry: {
+    app: './app',
+    services: './app/services.jsx'
+  },
   output: {
     path: path.resolve('build'),
-    filename: optimize ? 'app.[hash].js' : 'app.js'
+    filename: optimize ? '[name].[hash].js' : '[name].js'
   },
   resolve: {
     extensions: ['', '.js', '.jsx', '.json'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const path = require('path')
 
 const autoprefixer = require('autoprefixer')
 
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const pkg = require(path.resolve(__dirname, 'package.json'))
@@ -85,7 +84,7 @@ let loaders = [
  *   http://localhost:3000, proxified to the server app port
  */
 let plugins = [
-  new ExtractTextPlugin(optimize ? 'app.[hash].css' : 'app.css'),
+  extractor,
   new CopyPlugin([
     { from: 'vendor/assets', ignore: ['.gitkeep'] }
   ]),


### PR DESCRIPTION
WIP because of a wepback issue, see below. All the reste can be commented or discussed.

This PR declares a new route to serve services for intents (For now, only `CREATE` on `io.cozy.accounts` used in onboarding. See https://github.com/cozy/cozy-onboarding-v3/pull/26.

I tried several solutions to find the optimal way to serve this new route.

1. Specifying a fragment in the intent route, for example `#/services`. It should have been useful to use ReactRouter to directly redirect to the intent service component. But it does not works well, react router does not detect correctly the query string and it implies more code.
2. Define the app root as intent href, for example `/`, as proposed by @nono. But again, React Router adds a `#/` fragment to the URL and we still have to get the intent id by ourselves.

Finally, I kept the first idea, set a new route in `manifest.webapp`. It implied several changes in the webpack.config but it seems to work well, except that the main app does not load any CSS anymore. That the time to ping @m4dz.

